### PR TITLE
Use passport-strategy instead of passport

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
   "main": "./lib/passport-localapikey",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport": "0.2.x"
+    "passport-strategy": "1.x.x"
   },
   "devDependencies": {
-    "vows": "0.7.x"
+    "vows": "0.7.x",
+    "passport": "0.x.x"
   },
   "scripts": {
     "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"


### PR DESCRIPTION
There has recently been an update to `passport` which causes problems
unless we update to use the latest version of `passport` within this
module.  However, this will continue to be the case, and we should
instead use `passport-strategy` which decouples us from these changes.

For testing, we still have a dependency on `passport`, so I've moved
that dependency to the `devDependencies` section of the `package.json`.
Because this dependency is within the `devDependencies` section, it
won't interfere with installs of this package in the way described above.

For more information on the change in `passport` that caused this problem,
refer to this pull request:
https://github.com/jaredhanson/passport/pull/320

And this is an issue describing users encountering the problem, and
also a suggestion to switch `passport` to `passport-strategy`:
https://github.com/jaredhanson/passport/issues/400