### PR TITLE
Fix specific apiKeyHeader with uppercase

### DIFF
--- a/lib/passport-localapikey/strategy.js
+++ b/lib/passport-localapikey/strategy.js
@@ -94,7 +94,7 @@ Strategy.prototype.authenticate = function(req, options) {
     if (!obj) { return null; }
     var chain = field.split(']').join('').split('[');
     for (var i = 0, len = chain.length; i < len; i++) {
-      var prop = obj[chain[i]];
+      var prop = obj[chain[i]] || obj[chain[i].toLowerCase()];
       if (typeof(prop) === 'undefined') { return null; }
       if (typeof(prop) !== 'object') { return prop; }
       obj = prop;


### PR DESCRIPTION
Because of `bodyParser` always turn header into lowercase characters. I think maybe add NOTE in document or do this